### PR TITLE
chore: Update Speakeasy doc version to v3.1.0

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -2,7 +2,7 @@ lockVersion: 2.0.0
 id: 2bb10af9-e48a-4bd7-ae46-a35fa809dc29
 management:
   docChecksum: c079046e05a1d80ad361ab1f38ccee14
-  docVersion: v3.0.5
+  docVersion: v3.1.0
   speakeasyVersion: 1.617.1
   generationVersion: 2.701.8
   releaseVersion: 4.5.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -7,7 +7,7 @@ sources:
         tags:
             - latest
             - speakeasy-sdk-regen-1754440192
-            - v3.0.5
+            - v3.1.0
 targets:
     formance-sdk-typescript:
         source: stacks-source
@@ -22,7 +22,7 @@ workflow:
     sources:
         stacks-source:
             inputs:
-                - location: https://github.com/formancehq/stack/releases/download/v3.0.5/generate.json
+                - location: https://github.com/formancehq/stack/releases/download/v3.1.0/generate.json
             overlays:
                 - location: ./overlay.yaml
             registry:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     stacks-source:
         inputs:
-            - location: https://github.com/formancehq/stack/releases/download/v3.0.5/generate.json
+            - location: https://github.com/formancehq/stack/releases/download/v3.1.0/generate.json
         overlays:
             - location: ./overlay.yaml
         registry:


### PR DESCRIPTION
## Summary
- Updates the docVersion in .speakeasy/gen.lock from v3.0.5 to v3.1.0

## Test plan
- [ ] Verify the version has been updated in .speakeasy/gen.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)