### PR TITLE
chore: pin stacks-source to LATEST_RELEASE

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,7 +3,7 @@ speakeasyVersion: latest
 sources:
     stacks-source:
         inputs:
-            - location: registry.speakeasyapi.dev/formance/formance/stacks-source@latest
+            - location: registry.speakeasyapi.dev/formance/formance/stacks-source@LATEST_RELEASE
         overlays:
             - location: ./overlay.yaml
         registry:


### PR DESCRIPTION
## Summary
- Replace `@latest` with `@LATEST_RELEASE` in `.speakeasy/workflow.yaml` to use pinned release versions instead of floating latest tag.

## Test plan
- [ ] Verify speakeasy workflow runs correctly with the new source tag