### PR TITLE
fix: missing overlay for reconciliation Ledger Clarity list endpoints

### DIFF
--- a/overlay.yaml
+++ b/overlay.yaml
@@ -115,3 +115,18 @@ actions:
       - { 'name': 'query', 'in': 'query', 'content': { 'application/json': { 'schema': { 'type': 'object', 'additionalProperties': true } } } }
   - target: $["paths"]["/api/payments/v3/conversions"]["get"]["requestBody"]
     remove: true
+  - target: $["paths"]["/api/reconciliation/rules"]["get"]["parameters"]
+    update:
+      - { 'name': 'query', 'in': 'query', 'content': { 'application/json': { 'schema': { 'type': 'object', 'additionalProperties': true } } } }
+  - target: $["paths"]["/api/reconciliation/rules"]["get"]["requestBody"]
+    remove: true
+  - target: $["paths"]["/api/reconciliation/evaluations"]["get"]["parameters"]
+    update:
+      - { 'name': 'query', 'in': 'query', 'content': { 'application/json': { 'schema': { 'type': 'object', 'additionalProperties': true } } } }
+  - target: $["paths"]["/api/reconciliation/evaluations"]["get"]["requestBody"]
+    remove: true
+  - target: $["paths"]["/api/reconciliation/alerts"]["get"]["parameters"]
+    update:
+      - { 'name': 'query', 'in': 'query', 'content': { 'application/json': { 'schema': { 'type': 'object', 'additionalProperties': true } } } }
+  - target: $["paths"]["/api/reconciliation/alerts"]["get"]["requestBody"]
+    remove: true


### PR DESCRIPTION
## What

Adds the `query` parameter overlay for the three Reconciliation list endpoints introduced by the Ledger Clarity V1 API (reconciliation v2.4.0+):

- `GET /api/reconciliation/rules`
- `GET /api/reconciliation/evaluations`
- `GET /api/reconciliation/alerts`

## Why

These endpoints declare their query-builder filter as a `requestBody` on a `GET`, the same way ledger and payments do. A generated TypeScript client cannot issue that request — both browser `fetch` and Node's undici reject a GET carrying a body — so filtering would be unusable on all three lists.

The established fix in this repo is the overlay: it drops the GET `requestBody` and adds an equivalent `query` parameter. 24 endpoints across ledger, payments and the two legacy reconciliation lists (`/policies`, `/reconciliations`) are already handled this way. The three new endpoints were simply never added.

The reconciliation server already accepts both forms — `internal/api/utils.go` reads the body, then falls back to `r.URL.Query().Get("query")` — and the service's own docs describe `?query=` as supported (`docs/technical/api.md`). So this only aligns the generated client with the documented, implemented contract; no service change is required.

## Verification

Replicated the merge + overlay pipeline locally against the pinned reconciliation v2.4.1 release asset:

```
speakeasy overlay apply -s generate.json -o overlay.yaml --out build.json
→ Actions applied: 51   (45 before this change)
```

Resulting `build.json`, with `policies` shown as the reference:

| path | parameters | requestBody |
| --- | --- | --- |
| `/api/reconciliation/rules` | pageSize, cursor, **query** | removed |
| `/api/reconciliation/evaluations` | pageSize, cursor, **query** | removed |
| `/api/reconciliation/alerts` | pageSize, cursor, **query** | removed |
| `/api/reconciliation/policies` | pageSize, cursor, query | removed |

## Context

Needed for the Console integration of the Ledger Clarity API (EN-1729).